### PR TITLE
Remove implicit conversions.

### DIFF
--- a/example-rails-unicorn/app/views/trains/index.html.haml
+++ b/example-rails-unicorn/app/views/trains/index.html.haml
@@ -4,4 +4,4 @@
   .train
     %h3= train["destination"]
     .estimate
-      = [train["estimate"]].flatten.collect { |e| e["minutes"] + " mins" }.join(", ")
+      = [train["estimate"]].flatten.collect { |e| "#{e['minutes']} mins" }.join(", ")

--- a/example-rails/app/views/trains/index.html.haml
+++ b/example-rails/app/views/trains/index.html.haml
@@ -4,4 +4,4 @@
   .train
     %h3= train["destination"]
     .estimate
-      = [train["estimate"]].flatten.collect { |e| e["minutes"] + " mins" }.join(", ")
+      = [train["estimate"]].flatten.collect { |e| "#{e['minutes']} mins" }.join(", ")

--- a/rspec-consuming-db/app/views/trains/index.html.haml
+++ b/rspec-consuming-db/app/views/trains/index.html.haml
@@ -4,4 +4,4 @@
   .train
     %h3= train["destination"]
     .estimate
-      = [train["estimate"]].flatten.collect { |e| e["minutes"] + " mins" }.join(", ")
+      = [train["estimate"]].flatten.collect { |e| "#{e['minutes']} mins" }.join(", ")


### PR DESCRIPTION
I'm assuming sometimes the first part was an integer so the addition
would implicitely try to convert the " mins" string into an integer to
do the + operation. Using interpolation makes it clear we want strings
everywhere.

Resolves 500 received occasionally from this app with the following
error:

ActionView::Template::Error (can't convert String into Integer)