### PR TITLE
Fix demo-node-todo-v2

### DIFF
--- a/demo-node-todo-v2/app.js
+++ b/demo-node-todo-v2/app.js
@@ -36,9 +36,16 @@ app.get('/base.css', routes.base);
 app.get('/bg.png', routes.bg);
 app.get('/logo.jpg', routes.logo);
 app.get('/app.css', routes.appcss);
-app.get('/quit', function(req, res) {
-  process.exit(1);
-});
+app.get('/quit', function(req, res){
+            console.log('Exit button clicked.')
+            res.writeHead(200);
+            res.end("goodbye, world");
+            setTimeout(function() {
+                console.log("Attempting Exit(1)");
+                process.exit(1);
+            }, 1000);
+    }
+);
 
 app.get('/env', routes.env);
 
@@ -47,11 +54,11 @@ var startTime = new Date();
 
 app.get('/instance', function(req, res) {
   console.log('hello!')
-  console.log(req.host)
+  console.log(req.hostname)
   res.send({
     instance_id: uuid,
     start_time: startTime,
-    host: req.host
+    host: req.hostname
   });
 });
 


### PR DESCRIPTION
Addresses ENGT-2714.

Fixes odd issues with with restart policies when there is no HTTP response before exit(1).

Behavior pre and post 425e and apc 0.17.2/0.17.3 is now consistent.

1. Hit the Exit button in the app, 1 instance is killed and restarted.
2. Hit the Exit button again, a second instance is killed and restarted.
3. Hit the Exit button again within 5 minutes and the job is now flapping. The killed instance will wait 5 minutes before being restarted. 

@emil2k @juanman2 